### PR TITLE
infinite scroll fix

### DIFF
--- a/app/assets/javascripts/spree/vendor/jquery.infinite-pages.js.coffee
+++ b/app/assets/javascripts/spree/vendor/jquery.infinite-pages.js.coffee
@@ -57,7 +57,8 @@ Released under the MIT License
 # Check the distance of the nav selector from the bottom of the window and fire
 # load event if close enough
     check: ->
-      nav = @$container.find(@options.navSelector)
+#      nav = @$container.find(@options.navSelector)
+      nav = $('a[rel="next"]')
       if nav.size() == 0
         @_log "No more pages to load"
       else
@@ -80,7 +81,8 @@ Released under the MIT License
       else
         @_loading()
 
-        $.getScript(@$container.find(@options.navSelector).attr('href'))
+#        $.getScript(@$container.find(@options.navSelector).attr('href'))
+        $.getScript($('a[rel="next"]').attr('href'))
           .done(=> @_success())
           .fail(=> @_error())
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,4 +31,24 @@ module ApplicationHelper
 
     link_to text.html_safe, '#', class: "cart-info #{css_class}"
   end
+
+
+
+  def link_to_next_page_xpt(scope, name, **options)
+    next_page = next_page_path_xpt(scope, options)
+
+    options.except! :params, :param_name
+    options[:rel] ||= 'next'
+
+    if next_page
+      link_to name, next_page, options
+    elsif block_given?
+      yield
+    end
+  end
+
+  def next_page_path_xpt(scope, options = {})
+    Kaminari::Helpers::NextPage.new(self, **options.reverse_merge(current_page: scope.current_page, params: params)).url if scope.next_page
+  end
+
 end

--- a/app/views/spree/shared/_products.html.erb
+++ b/app/views/spree/shared/_products.html.erb
@@ -33,7 +33,7 @@
 
     <% if paginated_products.respond_to?(:total_pages) %>
       <p class="pagination">
-        <%= link_to_next_page(paginated_products, t('spree.pagination.next_page'), remote: true) %>
+        <%= link_to_next_page_xpt(paginated_products, t('spree.pagination.next_page'), remote: true) %>
       </p>
     <% end %>
   <% end %>


### PR DESCRIPTION
overrides kaminari link_to_next_page to include params in order to fix infinite scroll for filtered products